### PR TITLE
feat: Rename GPT4OEvaluator to LastFrameGPT4OEvaluator

### DIFF
--- a/examples/score_videos.py
+++ b/examples/score_videos.py
@@ -126,7 +126,7 @@ def run_human_evaluation(config: EvalConfig):
 
 def run_gpt4o_evaluation(config: EvalConfig):
     """Run single-frame GPT-4O evaluation."""
-    from vmevalkit.eval import GPT4OEvaluator
+    from vmevalkit.eval import LastFrameGPT4OEvaluator
     
     print("\n" + "=" * 60)
     print("GPT-4O EVALUATION")
@@ -141,7 +141,7 @@ def run_gpt4o_evaluation(config: EvalConfig):
         print("\nError: OPENAI_API_KEY not set in config or environment!")
         sys.exit(1)
     
-    scorer = GPT4OEvaluator(
+    scorer = LastFrameGPT4OEvaluator(
         inference_dir=config.inference_dir,
         eval_output_dir=config.eval_output_dir,
         temperature=config.temperature
@@ -184,7 +184,7 @@ def run_internvl_evaluation(config: EvalConfig):
 
 def run_multiframe_evaluation(config: EvalConfig, evaluator_type: str):
     """Run multi-frame evaluation with voting aggregation."""
-    from vmevalkit.eval import MultiFrameEvaluator, GPT4OEvaluator, InternVLEvaluator
+    from vmevalkit.eval import MultiFrameEvaluator, LastFrameGPT4OEvaluator, InternVLEvaluator
     
     mf = config.multiframe
     

--- a/vmevalkit/eval/__init__.py
+++ b/vmevalkit/eval/__init__.py
@@ -5,7 +5,7 @@ reasoning capabilities.
 
 Core evaluators (lazy-loaded due to heavy dependencies):
 - HumanEvaluator: Gradio-based human evaluation interface
-- GPT4OEvaluator: Automated evaluation using GPT-4O vision
+- LastFrameGPT4OEvaluator: Last-frame evaluation using GPT-4O vision
 - InternVLEvaluator: Automated evaluation using local VLM
 - MultiFrameEvaluator: Generic multi-frame evaluator wrapper (works with any base evaluator)
 
@@ -40,7 +40,7 @@ from .voting import (
 # Type hints for lazy-loaded classes
 if TYPE_CHECKING:
     from .human_eval import HumanEvaluator
-    from .gpt4o_eval import GPT4OEvaluator
+    from .gpt4o_eval import LastFrameGPT4OEvaluator
     from .internvl import InternVLEvaluator
     from .multiframe_eval import MultiFrameEvaluator
 
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 # Lazy loading for evaluators with heavy dependencies
 _LAZY_MODULES = {
     'HumanEvaluator': '.human_eval',
-    'GPT4OEvaluator': '.gpt4o_eval',
+    'LastFrameGPT4OEvaluator': '.gpt4o_eval',
     'InternVLEvaluator': '.internvl',
     'MultiFrameEvaluator': '.multiframe_eval',
 }
@@ -65,7 +65,7 @@ def __getattr__(name: str):
 __all__ = [
     # Core evaluators (lazy-loaded)
     'HumanEvaluator',
-    'GPT4OEvaluator',
+    'LastFrameGPT4OEvaluator',
     'InternVLEvaluator',
     'MultiFrameEvaluator',
     # Frame sampling

--- a/vmevalkit/eval/gpt4o_eval.py
+++ b/vmevalkit/eval/gpt4o_eval.py
@@ -1,4 +1,8 @@
-"""GPT-4O automatic evaluation for VMEvalKit."""
+"""Last-frame evaluation using GPT-4O for VMEvalKit.
+
+MODIFIED: Renamed from GPT4OEvaluator to LastFrameGPT4OEvaluator
+for better clarity and consistency with MultiFrameGPT4OEvaluator naming.
+"""
 
 import json
 import os
@@ -33,8 +37,8 @@ TASK_GUIDANCE = {
 }
 
 
-class GPT4OEvaluator:
-    """Automatic evaluation using GPT-4O vision model."""
+class LastFrameGPT4OEvaluator:
+    """Last-frame evaluation using GPT-4O vision model."""
     
     def __init__(self, 
                  inference_dir: str,
@@ -61,7 +65,7 @@ class GPT4OEvaluator:
     def _has_evaluation(self, model_name: str, task_type: str, task_id: str) -> bool:
         """Check if task has already been evaluated."""
         eval_path = self.eval_output_dir / model_name / task_type / task_id
-        eval_file = eval_path / "GPT4OEvaluator.json"
+        eval_file = eval_path / "LastFrameGPT4OEvaluator.json"
         return eval_file.exists()
     
     def extract_final_frame(self, video_path: str) -> np.ndarray:
@@ -252,10 +256,10 @@ class GPT4OEvaluator:
                     all_results[model_name] = await self.evaluate_model_async(model_name)
             
             # Save combined results
-            output_path = self.eval_output_dir / "GPT4OEvaluator_all_models.json"
+            output_path = self.eval_output_dir / "LastFrameGPT4OEvaluator_all_models.json"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             with open(output_path, 'w') as f:
-                json.dump({"metadata": {"evaluator": "GPT4OEvaluator", "timestamp": datetime.now().isoformat()},
+                json.dump({"metadata": {"evaluator": "LastFrameGPT4OEvaluator", "timestamp": datetime.now().isoformat()},
                           "results": all_results}, f, indent=2)
             return all_results
         finally:
@@ -270,10 +274,10 @@ class GPT4OEvaluator:
         task_output_dir = self.eval_output_dir / model_name / task_type / task_id
         task_output_dir.mkdir(parents=True, exist_ok=True)
         
-        with open(task_output_dir / "GPT4OEvaluator.json", 'w') as f:
+        with open(task_output_dir / "LastFrameGPT4OEvaluator.json", 'w') as f:
             json.dump({
                 "metadata": {
-                    "evaluator": "GPT4OEvaluator",
+                    "evaluator": "LastFrameGPT4OEvaluator",
                     "timestamp": datetime.now().isoformat(),
                     "model_name": model_name,
                     "task_type": task_type,


### PR DESCRIPTION
## Summary
Rename `GPT4OEvaluator` to `LastFrameGPT4OEvaluator` for better clarity and consistency.

## Motivation
- Current name doesn't clearly indicate last-frame evaluation
- Inconsistent with `MultiFrameGPT4OEvaluator` naming convention
- Makes the API more self-documenting

## Changes
- Rename class: `GPT4OEvaluator` → `LastFrameGPT4OEvaluator`
- Update output file naming: `GPT4OEvaluator.json` → `LastFrameGPT4OEvaluator.json`
- Update all imports and references in `__init__.py` and `score_videos.py`
- Add documentation clarifying this is a last-frame evaluator

## Testing
- ✅ Import test passed
- ✅ Full evaluation run successful
- ✅ Output file naming verified
- ✅ Integration with existing evaluation pipeline confirmed

## Breaking Changes
⚠️ **This is a breaking change:**
- Users must update import statements: `from vmevalkit.eval import LastFrameGPT4OEvaluator`
- Old class name `GPT4OEvaluator` is no longer available
- Output file names have changed for better clarity

## Files Changed
- `vmevalkit/eval/gpt4o_eval.py` - Class and file naming
- `vmevalkit/eval/__init__.py` - Exports and documentation
- `examples/score_videos.py` - Import statements and usage