### PR TITLE
Refactor evaluator structure for consistency

### DIFF
--- a/examples/score_videos.py
+++ b/examples/score_videos.py
@@ -126,7 +126,7 @@ def run_human_evaluation(config: EvalConfig):
 
 def run_gpt4o_evaluation(config: EvalConfig):
     """Run single-frame GPT-4O evaluation."""
-    from vmevalkit.eval import LastFrameGPT4OEvaluator
+    from vmevalkit.eval import GPT4OEvaluator
     
     print("\n" + "=" * 60)
     print("GPT-4O EVALUATION")
@@ -141,7 +141,7 @@ def run_gpt4o_evaluation(config: EvalConfig):
         print("\nError: OPENAI_API_KEY not set in config or environment!")
         sys.exit(1)
     
-    scorer = LastFrameGPT4OEvaluator(
+    scorer = GPT4OEvaluator(
         inference_dir=config.inference_dir,
         eval_output_dir=config.eval_output_dir,
         temperature=config.temperature
@@ -184,7 +184,7 @@ def run_internvl_evaluation(config: EvalConfig):
 
 def run_multiframe_evaluation(config: EvalConfig, evaluator_type: str):
     """Run multi-frame evaluation with voting aggregation."""
-    from vmevalkit.eval import MultiFrameEvaluator, LastFrameGPT4OEvaluator, InternVLEvaluator
+    from vmevalkit.eval import MultiFrameEvaluator, GPT4OEvaluator, InternVLEvaluator
     
     mf = config.multiframe
     
@@ -211,7 +211,7 @@ def run_multiframe_evaluation(config: EvalConfig, evaluator_type: str):
             sys.exit(1)
         base_evaluator = GPT4OEvaluator(
             inference_dir=config.inference_dir,
-            eval_output_dir=f"{config.eval_output_dir}/gpt4o",
+            eval_output_dir=config.eval_output_dir,
             temperature=config.temperature
         )
     else:  # internvl
@@ -220,7 +220,7 @@ def run_multiframe_evaluation(config: EvalConfig, evaluator_type: str):
         print(f"  - base_url: {base_url}")
         base_evaluator = InternVLEvaluator(
             inference_dir=config.inference_dir,
-            eval_output_dir=f"{config.eval_output_dir}/internvl",
+            eval_output_dir=config.eval_output_dir,
             api_key=api_key,
             base_url=base_url,
             temperature=config.temperature

--- a/vmevalkit/eval/__init__.py
+++ b/vmevalkit/eval/__init__.py
@@ -5,7 +5,7 @@ reasoning capabilities.
 
 Core evaluators (lazy-loaded due to heavy dependencies):
 - HumanEvaluator: Gradio-based human evaluation interface
-- LastFrameGPT4OEvaluator: Last-frame evaluation using GPT-4O vision
+- GPT4OEvaluator: Single-frame evaluation using GPT-4O vision
 - InternVLEvaluator: Automated evaluation using local VLM
 - MultiFrameEvaluator: Generic multi-frame evaluator wrapper (works with any base evaluator)
 
@@ -40,7 +40,7 @@ from .voting import (
 # Type hints for lazy-loaded classes
 if TYPE_CHECKING:
     from .human_eval import HumanEvaluator
-    from .gpt4o_eval import LastFrameGPT4OEvaluator
+    from .gpt4o_eval import GPT4OEvaluator
     from .internvl import InternVLEvaluator
     from .multiframe_eval import MultiFrameEvaluator
 
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 # Lazy loading for evaluators with heavy dependencies
 _LAZY_MODULES = {
     'HumanEvaluator': '.human_eval',
-    'LastFrameGPT4OEvaluator': '.gpt4o_eval',
+    'GPT4OEvaluator': '.gpt4o_eval',
     'InternVLEvaluator': '.internvl',
     'MultiFrameEvaluator': '.multiframe_eval',
 }
@@ -65,7 +65,7 @@ def __getattr__(name: str):
 __all__ = [
     # Core evaluators (lazy-loaded)
     'HumanEvaluator',
-    'LastFrameGPT4OEvaluator',
+    'GPT4OEvaluator',
     'InternVLEvaluator',
     'MultiFrameEvaluator',
     # Frame sampling

--- a/vmevalkit/eval/gpt4o_eval.py
+++ b/vmevalkit/eval/gpt4o_eval.py
@@ -1,7 +1,7 @@
-"""Last-frame evaluation using GPT-4O for VMEvalKit.
+"""GPT-4O vision model evaluator for VMEvalKit.
 
-MODIFIED: Renamed from GPT4OEvaluator to LastFrameGPT4OEvaluator
-for better clarity and consistency with MultiFrameGPT4OEvaluator naming.
+Provides single-frame evaluation using OpenAI's GPT-4O vision model.
+Can be used standalone or wrapped by MultiFrameEvaluator for multi-frame evaluation.
 """
 
 import json
@@ -37,8 +37,8 @@ TASK_GUIDANCE = {
 }
 
 
-class LastFrameGPT4OEvaluator:
-    """Last-frame evaluation using GPT-4O vision model."""
+class GPT4OEvaluator:
+    """GPT-4O vision model evaluator for single-frame evaluation."""
     
     def __init__(self, 
                  inference_dir: str,
@@ -65,7 +65,7 @@ class LastFrameGPT4OEvaluator:
     def _has_evaluation(self, model_name: str, task_type: str, task_id: str) -> bool:
         """Check if task has already been evaluated."""
         eval_path = self.eval_output_dir / model_name / task_type / task_id
-        eval_file = eval_path / "LastFrameGPT4OEvaluator.json"
+        eval_file = eval_path / "GPT4OEvaluator.json"
         return eval_file.exists()
     
     def extract_final_frame(self, video_path: str) -> np.ndarray:
@@ -256,10 +256,10 @@ class LastFrameGPT4OEvaluator:
                     all_results[model_name] = await self.evaluate_model_async(model_name)
             
             # Save combined results
-            output_path = self.eval_output_dir / "LastFrameGPT4OEvaluator_all_models.json"
+            output_path = self.eval_output_dir / "GPT4OEvaluator_summary.json"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             with open(output_path, 'w') as f:
-                json.dump({"metadata": {"evaluator": "LastFrameGPT4OEvaluator", "timestamp": datetime.now().isoformat()},
+                json.dump({"metadata": {"evaluator": "GPT4OEvaluator", "timestamp": datetime.now().isoformat()},
                           "results": all_results}, f, indent=2)
             return all_results
         finally:
@@ -274,10 +274,10 @@ class LastFrameGPT4OEvaluator:
         task_output_dir = self.eval_output_dir / model_name / task_type / task_id
         task_output_dir.mkdir(parents=True, exist_ok=True)
         
-        with open(task_output_dir / "LastFrameGPT4OEvaluator.json", 'w') as f:
+        with open(task_output_dir / "GPT4OEvaluator.json", 'w') as f:
             json.dump({
                 "metadata": {
-                    "evaluator": "LastFrameGPT4OEvaluator",
+                    "evaluator": "GPT4OEvaluator",
                     "timestamp": datetime.now().isoformat(),
                     "model_name": model_name,
                     "task_type": task_type,

--- a/vmevalkit/eval/multiframe_eval.py
+++ b/vmevalkit/eval/multiframe_eval.py
@@ -118,9 +118,8 @@ class MultiFrameEvaluator:
         """
         self.base_evaluator = base_evaluator
 
-        # Determine evaluator type for naming
-        base_class_name = base_evaluator.__class__.__name__
-        self.evaluator_name = f"MultiFrame{base_class_name}"
+        # Use base evaluator's name directly (evaluation method is indicated by directory path)
+        self.evaluator_name = base_evaluator.__class__.__name__
 
         # Multi-frame configuration
         self.n_frames = n_frames
@@ -470,7 +469,7 @@ class MultiFrameEvaluator:
                 all_results[model_name] = await self.evaluate_model_async(model_name)
 
         # Save combined results
-        output_path = self.output_dir / f"{self.evaluator_name}_all_models.json"
+        output_path = self.output_dir / f"{self.evaluator_name}_summary.json"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_path, 'w') as f:
             json.dump({


### PR DESCRIPTION
- Rename LastFrameGPT4OEvaluator back to GPT4OEvaluator
- Separate VLM type from evaluation method in naming
- Update output filenames to use VLM-based naming (GPT4OEvaluator.json)
- Update summary filenames (GPT4OEvaluator_summary.json)
- Update MultiFrameEvaluator to use consistent naming
- Ensure evaluation method is indicated by directory structure, not class name

This refactoring allows the same evaluator to be used for both single-frame and multi-frame evaluations, with the method determined by directory path.