### PR TITLE
fix: unify naming to 'last_frame' for consistency

### DIFF
--- a/examples/score_videos.py
+++ b/examples/score_videos.py
@@ -46,7 +46,7 @@ class EvalMethod(str, Enum):
 
 class SamplingStrategy(str, Enum):
     """Frame sampling strategies for video evaluation."""
-    SINGLE_FRAME = "single_frame"  # Single-frame evaluation (last frame)
+    LAST_FRAME = "last_frame"      # Single-frame evaluation (last frame)
     UNIFORM = "uniform"             # Multi-frame: uniform sampling
     KEYFRAME = "keyframe"           # Multi-frame: keyframe detection
     HYBRID = "hybrid"               # Multi-frame: hybrid strategy
@@ -555,9 +555,9 @@ Available methods:
         sampling_strategy = SamplingStrategy(multiframe_strategy)
         logger.info(f"Inferred multi-frame sampling strategy: {sampling_strategy.value}")
     else:
-        # Default to single-frame
-        sampling_strategy = SamplingStrategy.SINGLE_FRAME
-        logger.info("Defaulting to single-frame sampling strategy")
+        # Default to single-frame (last frame)
+        sampling_strategy = SamplingStrategy.LAST_FRAME
+        logger.info("Defaulting to last-frame sampling strategy")
     
     # 2. Determine evaluator
     if args.evaluator:
@@ -630,7 +630,7 @@ Available methods:
     # Run evaluation based on sampling strategy and evaluator
     logger.info(f"Starting evaluation: {sampling_strategy.value} + {evaluator.value}")
     
-    if sampling_strategy == SamplingStrategy.SINGLE_FRAME:
+    if sampling_strategy == SamplingStrategy.LAST_FRAME:
         # Single-frame evaluation
         if evaluator == Evaluator.HUMAN:
             run_human_evaluation(config)


### PR DESCRIPTION
Change SINGLE_FRAME to LAST_FRAME throughout the codebase to match:
- Config file name: last_frame.json
- Command line: --eval-method last_frame
- Output directory: evaluations/last_frame/

This provides consistent naming across the entire stack and is more accurate since the implementation specifically uses the last frame.

Changes:
- Rename SamplingStrategy.SINGLE_FRAME -> LAST_FRAME
- Update all references in evaluation logic
- Update default strategy logging message